### PR TITLE
Feat: #3 ROM 그래프와 통증수준 그래프를 일주일 단위로 보여주고 넘김이 가능하도록 적용

### DIFF
--- a/gacha/gacha/ViewModels/HistoryViewModel.swift
+++ b/gacha/gacha/ViewModels/HistoryViewModel.swift
@@ -32,8 +32,28 @@ class HistoryViewModel: ObservableObject {
     }
 
     let calendar = Calendar.current
-    let week = ["일", "월", "화", "수", "목", "금", "토"]
     
+    var week: [String] {
+        let formatter = DateFormatter()
+        formatter.locale = Locale.current
+        formatter.calendar = calendar
+        formatter.dateFormat = "EEE"
+        
+        let today = Date()
+        let weekdayIndex = calendar.component(.weekday, from: today) - 1 // 0=일, 6=토
+        guard let sunday = calendar.date(byAdding: .day, value: -weekdayIndex, to: today) else {
+            return ["Sun","Mon","Tue","Wed","Thu","Fri","Sat"] // fallback
+        }
+
+        return (0..<7).compactMap { i in
+            if let date = calendar.date(byAdding: .day, value: i, to: sunday) {
+                return formatter.string(from: date)
+            } else {
+                return nil
+            }
+        }
+    }
+        
     // MARK: - calculated property
     var romAverage: Int {
         guard !recentRecords.isEmpty else { return 0 }

--- a/gacha/gacha/ViewModels/HistoryViewModel.swift
+++ b/gacha/gacha/ViewModels/HistoryViewModel.swift
@@ -220,12 +220,14 @@ class HistoryViewModel: ObservableObject {
         )
         let days = max(components.day ?? 0, 0)  // 음수 방지
 
+        #if DEBUG
         print("📅 [daysBetweenRecords] 계산:")
         print("   - 첫 기록: \(firstDate) -> \(formatShortDate(firstDate))")
         print("   - 마지막 기록: \(lastDate) -> \(formatShortDate(lastDate))")
         print("   - 첫 날 시작: \(firstDayStart)")
         print("   - 마지막 날 시작: \(lastDayStart)")
         print("   - 날짜 차이: \(days)일")
+        #endif
 
         return days
     }
@@ -400,6 +402,7 @@ class HistoryViewModel: ObservableObject {
             let ascending = Array(fetchedRecords.reversed())
             allRecords = ascending
             recentRecords = Array(ascending.suffix(7))
+            #if DEBUG
             print(
                 "📅 loadRecentRecords - Total records: \(allRecords.count), Recent records: \(recentRecords.count)"
             )
@@ -408,6 +411,7 @@ class HistoryViewModel: ObservableObject {
                     "  [\(index)] Date: \(record.measuredDate), Formatted: \(formatShortDate(record.measuredDate))"
                 )
             }
+            #endif
         } catch {
             print("❌ 최근 기록 로드 실패: \(error)")
             recentRecords = []

--- a/gacha/gacha/ViewModels/HistoryViewModel.swift
+++ b/gacha/gacha/ViewModels/HistoryViewModel.swift
@@ -9,6 +9,11 @@ import Combine
 import SwiftData
 import SwiftUI
 
+enum ChartType: Hashable {
+    case rom
+    case pain
+}
+
 class HistoryViewModel: ObservableObject {
     private var repository: RecordRepository
 
@@ -17,8 +22,9 @@ class HistoryViewModel: ObservableObject {
     @Published var selectedROMDate: Date? = nil
     @Published var selectedPainDate: Date? = nil
     @Published var selectedROMIndex: Int? = nil  // 0~6 (일~토)
-    @Published var selectedPainIndex: Int? = nil
-    @Published var currentWeekOffset: Int = 0
+    @Published var selectedPainIndex: Int? = nil // 0~6 (일~토)
+    @Published var currentROMWeekOffset: Int = 0
+    @Published var currentPainWeekOffset: Int = 0
     @Published var isLoading: Bool = false
 
     init(repository: RecordRepository) {
@@ -27,7 +33,7 @@ class HistoryViewModel: ObservableObject {
 
     let calendar = Calendar.current
     let week = ["일", "월", "화", "수", "목", "금", "토"]
-
+    
     // MARK: - calculated property
     var romAverage: Int {
         guard !recentRecords.isEmpty else { return 0 }
@@ -406,9 +412,10 @@ class HistoryViewModel: ObservableObject {
         let record: MeasuredRecord?
     }
 
-    // currentWeekOffset에 따라 현재 주의 일-월의 데이터를 가공함
-    func getCurrentWeekData() -> [WeekDayData] {
-        let (startDate, endDate) = getWeekRange(offset: currentWeekOffset)
+    // 주어진 오프셋(기본: ROM 오프셋)에 따라 현재 주의 일-토 데이터를 가공함
+    func getCurrentWeekData(type: ChartType) -> [WeekDayData] {
+        let offset = type == .rom ? currentROMWeekOffset : currentPainWeekOffset
+        let (startDate, endDate) = getWeekRange(offset: offset)
 
         // 일주일의 날짜 배열 생성
         var weekDates: [Date] = []
@@ -421,7 +428,7 @@ class HistoryViewModel: ObservableObject {
 
         // 각 요일별(startDate ~ startDate+6)로 WeekDayData 생성; 기록 없으면 record: nil
         var recordsByDate: [Date: MeasuredRecord] = [:]
-        for record in recentRecords {
+        for record in allRecords {
             let day = calendar.startOfDay(for: record.measuredDate)
             if day >= calendar.startOfDay(for: startDate)
                 && day <= calendar.startOfDay(for: endDate)

--- a/gacha/gacha/ViewModels/HistoryViewModel.swift
+++ b/gacha/gacha/ViewModels/HistoryViewModel.swift
@@ -459,7 +459,7 @@ class HistoryViewModel: ObservableObject {
         
         // 0~6(일~토) 모두 포함, 기록 없으면 nil
         return (0..<7).map { i in
-            let date = calendar.date(byAdding: .day, value: i, to: startDate)!
+            let date = calendar.date(byAdding: .day, value: i, to: startDate) ?? startDate
             let day = calendar.startOfDay(for: date)
             return WeekDayData(
                 weekdayIndex: i,

--- a/gacha/gacha/ViewModels/HistoryViewModel.swift
+++ b/gacha/gacha/ViewModels/HistoryViewModel.swift
@@ -16,36 +16,43 @@ class HistoryViewModel: ObservableObject {
     @Published var recentRecords: [MeasuredRecord] = []
     @Published var selectedROMDate: Date? = nil
     @Published var selectedPainDate: Date? = nil
-    @Published var selectedROMIndex: Int? = nil
+    @Published var selectedROMIndex: Int? = nil  // 0~6 (일~토)
     @Published var selectedPainIndex: Int? = nil
-    
+    @Published var currentWeekOffset: Int = 0
     @Published var isLoading: Bool = false
-    
+
     init(repository: RecordRepository) {
         self.repository = repository
     }
-    
+
+    let calendar = Calendar.current
+    let week = ["일", "월", "화", "수", "목", "금", "토"]
+
     // MARK: - calculated property
     var romAverage: Int {
         guard !recentRecords.isEmpty else { return 0 }
-        let sum = recentRecords.compactMap { $0.ROM }.map { Int($0) }.reduce(0, +)
+        let sum = recentRecords.compactMap { $0.ROM }.map { Int($0) }.reduce(
+            0,
+            +
+        )
         return sum / recentRecords.count
     }
-    
+
     var dateRangeText: String {
         guard !recentRecords.isEmpty else { return "" }
-        
+
         // 데이터가 1개인 경우
         if recentRecords.count == 1,
-           let singleDate = recentRecords.first?.measuredDate {
+            let singleDate = recentRecords.first?.measuredDate
+        {
             let formatter = DateFormatter()
             formatter.dateFormat = "yyyy/M/d"
             return formatter.string(from: singleDate)
         }
-        
+
         // 데이터가 2개 이상인 경우
         guard let startDate = recentRecords.first?.measuredDate,
-              let endDate = recentRecords.last?.measuredDate
+            let endDate = recentRecords.last?.measuredDate
         else {
             return ""
         }
@@ -65,46 +72,60 @@ class HistoryViewModel: ObservableObject {
         }
         return max
     }
-    
+
     // MARK: - Summary Cards Data
-    
+
     var totalRecordCount: Int {
         allRecords.count
     }
-    
+
     /// 첫 번째 (가장 오래된) 기록 중 ROM 값이 존재하는 각도
     var firstAvailableROM: Int? {
         guard let record = allRecords.first(where: { $0.flexionAngle != nil }),
-              let rom = record.flexionAngle else { return nil }
+            let rom = record.flexionAngle
+        else { return nil }
         return Int(rom)
     }
-    
+
     /// 마지막 (가장 최근) 기록의 ROM
     /// 오늘 기록에 ROM이 없으면 이전 기록에서 가장 최근의 ROM 값을 반환
     var latestROM: Int? {
-        guard let record = allRecords.reversed().first(where: { $0.flexionAngle != nil }),
-              let rom = record.flexionAngle else { return nil }
+        guard
+            let record = allRecords.reversed().first(where: {
+                $0.flexionAngle != nil
+            }),
+            let rom = record.flexionAngle
+        else { return nil }
         return Int(rom)
     }
-    
+
     /// ROM 변화량 (최근 - 오래된)
     var romChange: Int? {
-        guard let first = firstAvailableROM, let latest = latestROM else { return nil }
+        guard let first = firstAvailableROM, let latest = latestROM else {
+            return nil
+        }
         return latest - first
     }
-    
+
     /// ROM 변화 설명 텍스트
     var romChangeText: String {
         guard totalRecordCount > 1,
-              let change = romChange,
-              change != 0 else {
+            let change = romChange,
+            change != 0
+        else {
             return Strings.History.cardRomSame(days: daysBetweenRecords)
         }
 
         if change > 0 {
-            return Strings.History.cardRomBetter(days: daysBetweenRecords, degrees: abs(change))
+            return Strings.History.cardRomBetter(
+                days: daysBetweenRecords,
+                degrees: abs(change)
+            )
         } else {
-            return Strings.History.cardRomWorse(days: daysBetweenRecords, degrees: abs(change))
+            return Strings.History.cardRomWorse(
+                days: daysBetweenRecords,
+                degrees: abs(change)
+            )
         }
     }
 
@@ -117,7 +138,8 @@ class HistoryViewModel: ObservableObject {
 
         // 첫 측정인 경우
         guard recentRecords.count > 1,
-              let todayROM = latestROM else {
+            let todayROM = latestROM
+        else {
             guard let firstROM = latestROM else {
                 return Strings.History.chartRomNoRecord
             }
@@ -126,7 +148,10 @@ class HistoryViewModel: ObservableObject {
 
         // 최근 일주일 이내의 최대 ROM (오늘 제외)
         let previousRecords = recentRecords.dropLast()
-        guard let maxPreviousROM = previousRecords.compactMap({ $0.flexionAngle }).max() else {
+        guard
+            let maxPreviousROM = previousRecords.compactMap({ $0.flexionAngle })
+                .max()
+        else {
             return Strings.History.chartRomFirstRecord(angle: todayROM)
         }
 
@@ -135,65 +160,78 @@ class HistoryViewModel: ObservableObject {
 
         // 비교 (ROM은 클수록 좋음)
         if Double(todayROM) > maxPreviousROM {
-            return Strings.History.chartRomBetter(improvement: difference, prevMax: maxPreviousROMInt)
+            return Strings.History.chartRomBetter(
+                improvement: difference,
+                prevMax: maxPreviousROMInt
+            )
         } else if Double(todayROM) == maxPreviousROM {
             return Strings.History.chartRomSame(prevMax: maxPreviousROMInt)
         } else {
-            return Strings.History.chartRomWorse(decline: difference, prevMax: maxPreviousROMInt)
+            return Strings.History.chartRomWorse(
+                decline: difference,
+                prevMax: maxPreviousROMInt
+            )
         }
     }
-    
+
     /// 첫 번째와 마지막 기록 사이의 날짜 차이 (일 단위)
     var daysBetweenRecords: Int {
         guard totalRecordCount > 1,
-              let firstDate = allRecords.first?.measuredDate,
-              let lastDate = allRecords.last?.measuredDate else {
+            let firstDate = allRecords.first?.measuredDate,
+            let lastDate = allRecords.last?.measuredDate
+        else {
             print("📅 [daysBetweenRecords] 기록이 1개 이하: \(totalRecordCount)")
             return 0
         }
-        
-        let calendar = Calendar.current
+
         // 각 날짜의 시작 시간을 기준으로 비교
         let firstDayStart = calendar.startOfDay(for: firstDate)
         let lastDayStart = calendar.startOfDay(for: lastDate)
-        let components = calendar.dateComponents([.day], from: firstDayStart, to: lastDayStart)
+        let components = calendar.dateComponents(
+            [.day],
+            from: firstDayStart,
+            to: lastDayStart
+        )
         let days = max(components.day ?? 0, 0)  // 음수 방지
-        
+
         print("📅 [daysBetweenRecords] 계산:")
         print("   - 첫 기록: \(firstDate) -> \(formatShortDate(firstDate))")
         print("   - 마지막 기록: \(lastDate) -> \(formatShortDate(lastDate))")
         print("   - 첫 날 시작: \(firstDayStart)")
         print("   - 마지막 날 시작: \(lastDayStart)")
         print("   - 날짜 차이: \(days)일")
-        
+
         return days
     }
-    
+
     /// 첫 번째 (가장 오래된) 기록 중 통증 레벨이 존재하는 값
     var firstAvailablePainLevel: Int? {
-        guard let record = allRecords.first(where: { $0.painLevel != nil }) else {
+        guard let record = allRecords.first(where: { $0.painLevel != nil })
+        else {
             return nil
         }
         return record.painLevel
     }
-    
+
     /// 마지막 (가장 최근) 기록의 통증 레벨
     var latestPainLevel: Int? {
         guard let last = allRecords.last else { return nil }
         return last.painLevel
     }
-    
+
     /// 통증 변화량 (처음 - 최근, 양수면 줄어든 것)
     var painChange: Int? {
-        guard let first = firstAvailablePainLevel, let latest = latestPainLevel else { return nil }
+        guard let first = firstAvailablePainLevel, let latest = latestPainLevel
+        else { return nil }
         return first - latest
     }
-    
+
     /// 통증 변화 설명 텍스트
     var painChangeText: String {
         guard totalRecordCount > 1,
-              let change = painChange,
-              change != 0 else {
+            let change = painChange,
+            change != 0
+        else {
             return Strings.History.cardPainSame
         }
 
@@ -213,7 +251,8 @@ class HistoryViewModel: ObservableObject {
 
         // 첫 측정인 경우 (기록이 1개만 있을 때)
         guard recentRecords.count > 1,
-              let todayPain = latestPainLevel else {
+            let todayPain = latestPainLevel
+        else {
             guard let firstPain = latestPainLevel else {
                 return Strings.History.chartPainNoRecord
             }
@@ -222,7 +261,10 @@ class HistoryViewModel: ObservableObject {
 
         // 최근 일주일 이내의 최소 통증 레벨 (오늘 제외, 통증은 낮을수록 좋음)
         let previousRecords = recentRecords.dropLast()
-        guard let minPreviousPain = previousRecords.compactMap({ $0.painLevel }).min() else {
+        guard
+            let minPreviousPain = previousRecords.compactMap({ $0.painLevel })
+                .min()
+        else {
             return Strings.History.chartPainFirstRecord(level: todayPain)
         }
 
@@ -230,77 +272,82 @@ class HistoryViewModel: ObservableObject {
 
         // 비교 (통증은 낮을수록 좋음)
         if todayPain < minPreviousPain {
-            return Strings.History.chartPainBetter(improvement: difference, from: minPreviousPain)
+            return Strings.History.chartPainBetter(
+                improvement: difference,
+                from: minPreviousPain
+            )
         } else if todayPain == minPreviousPain {
             return Strings.History.chartPainSame(level: minPreviousPain)
         } else {
-            return Strings.History.chartPainWorse(increase: difference, from: minPreviousPain)
+            return Strings.History.chartPainWorse(
+                increase: difference,
+                from: minPreviousPain
+            )
         }
     }
-    
+
     // MARK: - Chart Y-Axis Range
-    
+
     var romMinValue: Double {
         // extensionAngle 값들 중 최소값 계산
-        let validExtensionAngles = recentRecords
+        let validExtensionAngles =
+            recentRecords
             .compactMap { $0.extensionAngle }
             .filter { $0.isFinite }
-        
+
         guard let minExtension = validExtensionAngles.min() else {
             // extensionAngle이 없는 경우 기본값 0
             return 0
         }
-        
+
         // 0보다 작으면 0으로 제한
         return max(minExtension, 0)
     }
-    
+
     var romMaxValue: Double {
         // Use only finite, non-negative angles to avoid invalid ranges or NaN propagation
-        let validAngles = recentRecords
+        let validAngles =
+            recentRecords
             .compactMap { $0.flexionAngle }
             .filter { $0.isFinite && $0 >= 0 }
-        
+
         guard let maxROM = validAngles.max() else {
             // Safe default when no valid angles exist
             return 0
         }
-        
+
         // Padding for headroom; ensure upper bound is positive
         let padded = maxROM + 10
         return max(padded, 1)
     }
-    
+
     var painMaxValue: Double {
         guard !recentRecords.isEmpty else { return 10 }
-        let maxPain = recentRecords.compactMap { $0.painLevel }.map { Double($0) }.max() ?? 0
+        let maxPain =
+            recentRecords.compactMap { $0.painLevel }.map { Double($0) }.max()
+            ?? 0
         // 데이터의 최댓값을 그대로 사용 (0일 경우 최소 1로 설정)
         return max(maxPain, 1)
     }
-    
+
     // MARK: - Chart X-Axis Dates
-    
+
     var recordDates: [Date] {
         recentRecords.map { $0.measuredDate }
     }
-    
+
     var chartIndices: [Int] {
         Array(0..<recentRecords.count)
     }
-    
+
     var chartIndicesAsDouble: [Double] {
         chartIndices.map { Double($0) }
     }
-    
+
     // MARK: - Chart Data
-    
+
     var chartData: [(index: Int, record: MeasuredRecord)] {
         Array(recentRecords.enumerated().map { (index: $0, record: $1) })
-    }
-    
-    var xAxisDomain: ClosedRange<Double> {
-        let maxIndex = Double(max(0, recentRecords.count-1))
-        return -0.3...(maxIndex + 0.8)
     }
 
     // MARK: - Helper Methods
@@ -317,27 +364,31 @@ class HistoryViewModel: ObservableObject {
         let result = formatter.string(from: date)
         return result
     }
-    
+
     func loadRecentRecords() async {
         isLoading = true
         defer { isLoading = false }
-        
+
         do {
             let fetchedRecords = try await repository.loadRecords()
             let ascending = Array(fetchedRecords.reversed())
             allRecords = ascending
             recentRecords = Array(ascending.suffix(7))
-            print("📅 loadRecentRecords - Total records: \(allRecords.count), Recent records: \(recentRecords.count)")
+            print(
+                "📅 loadRecentRecords - Total records: \(allRecords.count), Recent records: \(recentRecords.count)"
+            )
             for (index, record) in recentRecords.enumerated() {
-                print("  [\(index)] Date: \(record.measuredDate), Formatted: \(formatShortDate(record.measuredDate))")
+                print(
+                    "  [\(index)] Date: \(record.measuredDate), Formatted: \(formatShortDate(record.measuredDate))"
+                )
             }
         } catch {
             print("❌ 최근 기록 로드 실패: \(error)")
             recentRecords = []
         }
     }
-    
-    func formatDateRange(startDate: Date, endDate: Date) -> String{
+
+    func formatDateRange(startDate: Date, endDate: Date) -> String {
         let formatter = DateFormatter()
         formatter.locale = Locale.current
         formatter.dateFormat = "yyyy/M/d"
@@ -348,4 +399,81 @@ class HistoryViewModel: ObservableObject {
 
         return "\(start)~\(end)"
     }
+
+    struct WeekDayData {
+        let weekdayIndex: Int  // 0(일)~6(토)
+        let date: Date
+        let record: MeasuredRecord?
+    }
+
+    // currentWeekOffset에 따라 현재 주의 일-월의 데이터를 가공함
+    func getCurrentWeekData() -> [WeekDayData] {
+        let (startDate, endDate) = getWeekRange(offset: currentWeekOffset)
+
+        // 일주일의 날짜 배열 생성
+        var weekDates: [Date] = []
+        for i in 0..<7 {
+            if let date = calendar.date(byAdding: .day, value: i, to: startDate)
+            {
+                weekDates.append(date)
+            }
+        }
+
+        // 각 요일별(startDate ~ startDate+6)로 WeekDayData 생성; 기록 없으면 record: nil
+        var recordsByDate: [Date: MeasuredRecord] = [:]
+        for record in recentRecords {
+            let day = calendar.startOfDay(for: record.measuredDate)
+            if day >= calendar.startOfDay(for: startDate)
+                && day <= calendar.startOfDay(for: endDate)
+            {
+                recordsByDate[day] = record
+            }
+        }
+        
+        // 0~6(일~토) 모두 포함, 기록 없으면 nil
+        return (0..<7).map { i in
+            let date = calendar.date(byAdding: .day, value: i, to: startDate)!
+            let day = calendar.startOfDay(for: date)
+            return WeekDayData(
+                weekdayIndex: i,
+                date: date,
+                record: recordsByDate[day]
+            )
+        }
+    }
+
+    private func getWeekRange(offset: Int) -> (start: Date, end: Date) {
+        let today = Date()
+
+        // 현재 주의 시작(일요일)을 구함
+        let weekday = calendar.component(.weekday, from: today) - 1
+        guard
+            let thisWeekStart = calendar.date(
+                byAdding: .day,
+                value: -weekday,
+                to: today
+            )
+        else {
+            return (today, today)
+        }
+
+        // offset만큼 이전 주로 이동
+        guard
+            let targetWeekStart = calendar.date(
+                byAdding: .weekOfYear,
+                value: -offset,
+                to: thisWeekStart
+            ),
+            let targetWeekEnd = calendar.date(
+                byAdding: .day,
+                value: 6,
+                to: targetWeekStart
+            )
+        else {
+            return (start: today, today)
+        }
+
+        return (targetWeekStart, targetWeekEnd)
+    }
 }
+

--- a/gacha/gacha/Views/DashBoard/HistoryView.swift
+++ b/gacha/gacha/Views/DashBoard/HistoryView.swift
@@ -2,7 +2,7 @@
 //  History.swift
 //  gacha
 //
-//  Created by 차원준 on 10/26/25.
+//  Created by 차원준 on 24/01/26.
 //
 
 import Charts
@@ -39,7 +39,6 @@ struct History: View {
                             VStack(alignment: .leading, spacing: 16) {
                                 ChartText(chartType: .rom)
                                 if !vm.chartData.isEmpty {
-                                    romChartButton
                                     romChart
                                 }
                             }
@@ -76,31 +75,53 @@ struct History: View {
 
     // MARK: - Chart Text
     private func ChartText(chartType: ChartType) -> some View {
-        return VStack(alignment: .leading, spacing: 4) {
-            // Title
-            Text(
-                chartType == .rom
-                    ? Strings.History.chartRomTitle
-                    : Strings.History.chartPainTitle
-            )
-            .font(.displaySublineBold)
-            .foregroundColor(.blue700)
-            .id(chartType == .rom ? "romChart" : "painChart")
-            // Subtitle
-            if vm.chartData.isEmpty {
+        let weekData = vm.getCurrentWeekData()
+        let calendar = Calendar.current
+
+        return VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: 4) {
+                // Title
                 Text(
                     chartType == .rom
-                        ? Strings.History.chartRomNoRecord
-                        : Strings.History.chartPainNoRecord
+                        ? Strings.History.chartRomTitle
+                        : Strings.History.chartPainTitle
                 )
-                .font(.displayFootnoteRegular)
-                .frame(
-                    maxWidth: .infinity,
-                    alignment: .leading
-                )
-            } else {
-                Text(chartType == .rom ? vm.romSubtitle : vm.painSubtitle)
+                .font(.displaySublineBold)
+                .foregroundColor(.blue700)
+                .id(chartType == .rom ? "romChart" : "painChart")
+                // Subtitle
+                if vm.chartData.isEmpty {
+                    Text(
+                        chartType == .rom
+                            ? Strings.History.chartRomNoRecord
+                            : Strings.History.chartPainNoRecord
+                    )
                     .font(.displayFootnoteRegular)
+                    .frame(
+                        maxWidth: .infinity,
+                        alignment: .leading
+                    )
+                } else {
+                    Text(chartType == .rom ? vm.romSubtitle : vm.painSubtitle)
+                        .font(.displayFootnoteRegular)
+                }
+            }
+            // Buttons & Date
+            if !vm.chartData.isEmpty {
+                HStack {
+                    romChartButtonLeft
+
+                    Spacer()
+
+                    Text(
+                        "\(vm.formatDate(weekData.first?.date ?? Date())) - \(vm.formatDate(weekData.last?.date ?? Date()))"
+                    )
+                    .font(.displayFootnoteRegular)
+
+                    Spacer()
+
+                    romChartButtonRight
+                }
             }
         }
         .opacity(
@@ -114,29 +135,84 @@ struct History: View {
         )
     }
 
-    private var romChartButton: some View {
-        return HStack {
-            Button {
-                vm.currentWeekOffset += 1
-                vm.selectedROMIndex = nil
+    private var romChartButtonLeft: some View {
+        // 현재 주(오프셋 적용)의 주간 범위 계산
+        let weekData = vm.getCurrentWeekData()
+        let calendar = Calendar.current
+        let currentWeekDates = weekData.compactMap { $0.date }
+        let currentWeekStart = currentWeekDates.min()
+        let currentWeekEnd = currentWeekDates.max()
 
+        // 전체 데이터의 첫/마지막 날짜
+        let dataStart = vm.recentRecords.first?.measuredDate
+        let dataEnd = vm.recentRecords.last?.measuredDate
+
+        // 왼쪽(과거로 이동): 이동 후 주의 끝이 데이터 시작일보다 앞서면 비활성화
+        let disableLeft: Bool = {
+            guard let currentWeekStart, let currentWeekEnd, let dataStart else {
+                return true
+            }
+            guard
+                let previousWeekEnd = calendar.date(
+                    byAdding: .day,
+                    value: -1,
+                    to: currentWeekStart
+                )
+            else { return true }
+            return previousWeekEnd < calendar.startOfDay(for: dataStart)
+        }()
+
+        return
+            Button {
+                if !disableLeft {
+                    vm.currentWeekOffset += 1
+                    vm.selectedROMIndex = nil
+                }
             } label: {
                 Image(systemName: "chevron.left")
             }
-            //            .disabled()
+            .disabled(disableLeft)
+    }
 
-            Spacer()
+    private var romChartButtonRight: some View {
+        // 현재 주(오프셋 적용)의 주간 범위 계산
+        let weekData = vm.getCurrentWeekData()
+        let calendar = Calendar.current
+        let currentWeekDates = weekData.compactMap { $0.date }
+        let currentWeekStart = currentWeekDates.min()
+        let currentWeekEnd = currentWeekDates.max()
 
+        // 전체 데이터의 첫/마지막 날짜
+        let dataStart = vm.recentRecords.first?.measuredDate
+        let dataEnd = vm.recentRecords.last?.measuredDate
+
+        // 오른쪽(미래로 이동): 이동 후 주의 시작이 데이터 마지막보다 뒤면 비활성화
+        let disableRight: Bool = {
+            guard let currentWeekStart, let currentWeekEnd, let dataEnd else {
+                return true
+            }
+            guard
+                let nextWeekStart = calendar.date(
+                    byAdding: .day,
+                    value: 1,
+                    to: currentWeekEnd
+                )
+            else { return true }
+            return calendar.startOfDay(for: nextWeekStart)
+                > calendar.startOfDay(for: dataEnd)
+        }()
+
+        return
             Button {
-                vm.currentWeekOffset -= 1
-                vm.selectedROMIndex = nil
-
+                if !disableRight {
+                    vm.currentWeekOffset -= 1
+                    vm.selectedROMIndex = nil
+                }
             } label: {
                 Image(systemName: "chevron.right")
             }
-            //            .disabled()
-        }
-        .padding(.horizontal)
+            .disabled(disableRight)
+
     }
 
     // MARK: - Chart Views

--- a/gacha/gacha/Views/DashBoard/HistoryView.swift
+++ b/gacha/gacha/Views/DashBoard/HistoryView.swift
@@ -10,7 +10,6 @@ import SwiftData
 import SwiftUI
 
 struct History: View {
-    @Environment(\.dismiss) private var dismiss
     @EnvironmentObject var vm: HistoryViewModel
 
     // MARK: - Body
@@ -24,28 +23,24 @@ struct History: View {
                         VStack(spacing: 32) {
                             // MARK: - Summary Cards
                             HStack(spacing: 14) {
-                                // 무릎 굽힘 범위 카드
+                                // Rom Card
                                 romSummaryCard(proxy: proxy)
 
-                                // 통증 정도 카드
+                                // Pain Card
                                 painSummaryCard(proxy: proxy)
                             }
 
-                            // MARK: - 무릎 가동범위 추이
+                            // MARK: - ROM Chart
                             VStack(alignment: .leading, spacing: 16) {
-
-                                VStack(alignment: .leading, spacing: 8) {
+                                // Text
+                                VStack(alignment: .leading, spacing: 4) {
                                     // Title
                                     Text(Strings.History.chartRomTitle)
                                         .font(.displaySublineBold)
                                         .foregroundColor(.blue700)
                                         .id("romChart")
-                                    // 인덱스 존재 -> 투명하게, 부재 -> 보이게
-                                        .opacity(vm.selectedROMIndex != nil ? 0 : 1)
-                                        .animation(.easeInOut(duration: 0.1), value: vm.selectedROMIndex)
-                                    
+                                    // Subtitle
                                     if vm.chartData.isEmpty {
-                                        // 측정된 데이터가 없을 때
                                         Text(Strings.History.chartRomNoRecord)
                                             .font(.displayFootnoteRegular)
                                             .frame(
@@ -53,38 +48,41 @@ struct History: View {
                                                 alignment: .leading
                                             )
                                     } else {
-                                        // SubTitle
                                         Text(vm.romSubtitle)
                                             .font(.displayFootnoteRegular)
-                                        // 인덱스 존재 -> 투명하게, 부재 -> 보이게
-                                            .opacity(vm.selectedROMIndex != nil ? 0 : 1)
-                                            .animation(.easeInOut(duration: 0.1), value: vm.selectedROMIndex)
-                                        
-                                        romChart
-
                                     }
                                 }
-                                .frame(maxWidth: .infinity)
-                                .padding(16)
-                                .background(Color("White"))
-                                .cornerRadius(24)
+                                .opacity(
+                                    vm.selectedROMIndex != nil ? 0 : 1
+                                )
+                                .animation(
+                                    .easeInOut(duration: 0.1),
+                                    value: vm.selectedROMIndex
+                                )
+                                
+                                // Chart
+                                if !vm.chartData.isEmpty {
+                                    romChart
+                                }
                             }
+                            .frame(maxWidth: .infinity)
+                            .padding(16)
+                            .background(.white)
+                            .cornerRadius(24)
 
-                            // MARK: - 통증 수준 추이
+                            // MARK: - Pain Chart
                             VStack(alignment: .leading, spacing: 16) {
-
-                                VStack(alignment: .leading, spacing: 8) {
+                                // Text
+                                VStack(alignment: .leading, spacing: 4) {
                                     // Title
                                     Text(Strings.History.chartPainTitle)
                                         .font(.displaySublineBold)
                                         .foregroundColor(.blue700)
                                         .id("painChart")
-                                    // 인덱스 존재 -> 투명하게, 부재 -> 보이게
-                                        .opacity(vm.selectedPainIndex != nil ? 0 : 1)
-                                        .animation(.easeInOut(duration: 0.1), value: vm.selectedPainIndex)
-                                    
+
+                                    // Subtitle
                                     if vm.chartData.isEmpty {
-                                        // 측정된 데이터가 없을 때
+                                        // No Data
                                         Text(Strings.History.chartPainNoRecord)
                                             .font(.displayFootnoteRegular)
                                             .frame(
@@ -92,20 +90,26 @@ struct History: View {
                                                 alignment: .leading
                                             )
                                     } else {
-                                        // SubTitle
                                         Text(vm.painSubtitle)
                                             .font(.displayFootnoteRegular)
-                                        // 인덱스 존재 -> 투명하게, 부재 -> 보이게
-                                            .opacity(vm.selectedPainIndex != nil ? 0 : 1)
-                                            .animation(.easeInOut(duration: 0.1), value: vm.selectedPainIndex)
-                                        painChart
                                     }
+                                }.opacity(
+                                    vm.selectedPainIndex != nil ? 0 : 1
+                                )
+                                .animation(
+                                    .easeInOut(duration: 0.1),
+                                    value: vm.selectedPainIndex
+                                )
+                                
+                                // Chart
+                                if !vm.chartData.isEmpty {
+                                    painChart
                                 }
-                                .frame(maxWidth: .infinity)
-                                .padding(16)
-                                .background(Color("White"))
-                                .cornerRadius(24)
                             }
+                            .frame(maxWidth: .infinity)
+                            .padding(16)
+                            .background(.white)
+                            .cornerRadius(24)
                         }
                         .padding(.horizontal, 20)
                         .padding(.top, 20)
@@ -142,17 +146,17 @@ struct History: View {
                 )
                 .cornerRadius(4)
             }
-            
+
             // 도딘의 유산
             // 130도 기준선
-//            RuleMark(y: .value("Target", 130))
-//                .foregroundStyle(Color("Blue700"))
-//                .lineStyle(StrokeStyle(lineWidth: 1, dash: [5, 5]))
-//                .annotation(position: .trailing, alignment: .center) {
-//                    Text("130°")
-//                        .font(.displayCaption1Regular)
-//                        .foregroundStyle(Color("Blue700"))
-//                }
+            //            RuleMark(y: .value("Target", 130))
+            //                .foregroundStyle(Color("Blue700"))
+            //                .lineStyle(StrokeStyle(lineWidth: 1, dash: [5, 5]))
+            //                .annotation(position: .trailing, alignment: .center) {
+            //                    Text("130°")
+            //                        .font(.displayCaption1Regular)
+            //                        .foregroundStyle(Color("Blue700"))
+            //                }
 
             if let selectedIndex = selectedIndex,
                 selectedIndex >= 0 && selectedIndex < data.count
@@ -205,7 +209,7 @@ struct History: View {
         }
         .chartYScale(domain: 0...max(150, vm.romMaxValue))
         .chartXScale(domain: domain)
-        .chartXSelection(value: $vm.selectedROMIndex) //롱프레스 감지
+        .chartXSelection(value: $vm.selectedROMIndex)  //롱프레스 감지
         .frame(height: 361)
         .padding(.top, 20)
     }
@@ -222,10 +226,12 @@ struct History: View {
                     .foregroundStyle(Color("Gray700"))
                     .frame(maxWidth: .infinity, alignment: .topLeading)
 
-                Text("\(Int(selectedRecord.extensionAngle ?? 0))°~\(Int(selectedRecord.flexionAngle ?? 0))°")
-                    .font(.displayTitle2Semibold)
-                    .foregroundStyle(Color("Gray900"))
-                    .frame(maxWidth: .infinity, alignment: .topLeading)
+                Text(
+                    "\(Int(selectedRecord.extensionAngle ?? 0))°~\(Int(selectedRecord.flexionAngle ?? 0))°"
+                )
+                .font(.displayTitle2Semibold)
+                .foregroundStyle(Color("Gray900"))
+                .frame(maxWidth: .infinity, alignment: .topLeading)
 
                 Text(vm.formatDate(selectedRecord.measuredDate))
                     .font(.displayCaption1Semibold)
@@ -343,115 +349,112 @@ struct History: View {
 
     @ViewBuilder
     private func romSummaryCard(proxy: ScrollViewProxy) -> some View {
-            VStack(alignment: .leading) {
+        VStack(alignment: .leading) {
 
-                // ROM 수치 표시
-                HStack(spacing: 0) {
-                    if vm.totalRecordCount < 2 {
-                    } else if let first = vm.firstAvailableROM,
-                              let latest = vm.latestROM
-                    {
-                        // 기록이 여러 개일 때
-                        let change = latest - first
-                        Text("\(change > 0 ? "↑" : "")\(change)°")
-                            .font(.roundedTitle1Bold)
-                            .foregroundColor(Color("Gray900"))
-                    }
-                    Spacer()
-
+            // ROM 수치 표시
+            HStack(spacing: 0) {
+                if vm.totalRecordCount < 2 {
+                } else if let first = vm.firstAvailableROM,
+                    let latest = vm.latestROM
+                {
+                    // 기록이 여러 개일 때
+                    let change = latest - first
+                    Text("\(change > 0 ? "↑" : "")\(change)°")
+                        .font(.roundedTitle1Bold)
+                        .foregroundColor(Color("Gray900"))
                 }
-                
                 Spacer()
 
-                VStack(alignment:.leading, spacing: 4){
-                    // 헤더
-                    HStack {
-                        Text(Strings.History.cardRomTitle)
-                            .font(.displaySublineBold)
-                            .foregroundColor(Color("Blue700"))
-                    }
-        
-
-                    // 변화 설명 텍스트
-                    Text(
-                        vm.totalRecordCount < 2
-                            ? Strings.History.cardRomUnder2
-                            : vm.romChangeText
-                    )
-                    .font(
-                        vm.totalRecordCount < 2
-                            ? .displayFootnoteRegular : .displayCalloutRegular
-                    )
-                    .foregroundColor(Color("Gray700"))
-                    .lineLimit(3)
-                }
-                
-
             }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 16)
-            .frame(width: 173, height: 173)
-            .background(Color.white)
-            .cornerRadius(15)
+
+            Spacer()
+
+            VStack(alignment: .leading, spacing: 4) {
+                // 헤더
+                HStack {
+                    Text(Strings.History.cardRomTitle)
+                        .font(.displaySublineBold)
+                        .foregroundColor(Color("Blue700"))
+                }
+
+                // 변화 설명 텍스트
+                Text(
+                    vm.totalRecordCount < 2
+                        ? Strings.History.cardRomUnder2
+                        : vm.romChangeText
+                )
+                .font(
+                    vm.totalRecordCount < 2
+                        ? .displayFootnoteRegular : .displayCalloutRegular
+                )
+                .foregroundColor(Color("Gray700"))
+                .lineLimit(3)
+            }
+
         }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 16)
+        .frame(width: 173, height: 173)
+        .background(Color.white)
+        .cornerRadius(15)
+    }
     @ViewBuilder
     private func painSummaryCard(proxy: ScrollViewProxy) -> some View {
 
-            VStack(alignment: .leading) {
-                
-                // 통증 레벨 바 표시
-                HStack(spacing: 0) {
-                    if vm.totalRecordCount < 2 {
+        VStack(alignment: .leading) {
 
-                    } else if let first = vm.firstAvailablePainLevel,
-                              let latest = vm.latestPainLevel
-                    {
-                        // 기록이 여러 개일 때
-                        let change = latest - first
-                        Text("\(change < 0 ? "↓" : "")\(abs(change)) \(Strings.History.cardPainStep)")
-                            .font(.roundedTitle1Bold)
-                            .foregroundColor(Color("Gray900"))
-                    }
-                    Spacer()
-                }
-                
-                Spacer()
+            // 통증 레벨 바 표시
+            HStack(spacing: 0) {
+                if vm.totalRecordCount < 2 {
 
-                VStack(alignment:.leading, spacing: 4){
-                    
-                    
-                    // 헤더
-                    HStack {
-                        Text(Strings.History.chartPainTitle)
-                            .font(.displaySublineBold)
-                            .foregroundColor(Color("Blue700"))
-                    }
-                    
-                    
-                    
-                    // 변화 설명 텍스트
+                } else if let first = vm.firstAvailablePainLevel,
+                    let latest = vm.latestPainLevel
+                {
+                    // 기록이 여러 개일 때
+                    let change = latest - first
                     Text(
-                        vm.totalRecordCount == 0
+                        "\(change < 0 ? "↓" : "")\(abs(change)) \(Strings.History.cardPainStep)"
+                    )
+                    .font(.roundedTitle1Bold)
+                    .foregroundColor(Color("Gray900"))
+                }
+                Spacer()
+            }
+
+            Spacer()
+
+            VStack(alignment: .leading, spacing: 4) {
+
+                // 헤더
+                HStack {
+                    Text(Strings.History.chartPainTitle)
+                        .font(.displaySublineBold)
+                        .foregroundColor(Color("Blue700"))
+                }
+
+                // 변화 설명 텍스트
+                Text(
+                    vm.totalRecordCount == 0
                         ? Strings.History.cardPainNoRecord
                         : (vm.totalRecordCount < 2
-                           ? Strings.History.cardPainFirstRecord
-                           : vm.painChangeText)
-                    )
-                    .font(
-                        vm.totalRecordCount < 2
+                            ? Strings.History.cardPainFirstRecord
+                            : vm.painChangeText)
+                )
+                .font(
+                    vm.totalRecordCount < 2
                         ? .displayFootnoteRegular : .displayCalloutRegular
-                    )
-                    .foregroundColor(Color("Gray700"))
-                    .lineLimit(3)
-                }
+                )
+                .foregroundColor(Color("Gray700"))
+                .lineLimit(3)
             }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 16)
-            .frame(width: 173, height: 173)
-            .background(Color.white)
-            .cornerRadius(15)
-//        }
-        
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 16)
+        .frame(width: 173, height: 173)
+        .background(Color.white)
+        .cornerRadius(15)
+        //        }
+
     }
 
     // MARK: - Helper Methods

--- a/gacha/gacha/Views/DashBoard/HistoryView.swift
+++ b/gacha/gacha/Views/DashBoard/HistoryView.swift
@@ -77,88 +77,108 @@ struct History: View {
     private func ChartText(chartType: ChartType) -> some View {
         return VStack(alignment: .leading, spacing: 4) {
             // Title
-            Text(chartType == .rom ? Strings.History.chartRomTitle : Strings.History.chartPainTitle)
-                .font(.displaySublineBold)
-                .foregroundColor(.blue700)
-                .id(chartType == .rom ? "romChart" : "painChart")
+            Text(
+                chartType == .rom
+                    ? Strings.History.chartRomTitle
+                    : Strings.History.chartPainTitle
+            )
+            .font(.displaySublineBold)
+            .foregroundColor(.blue700)
+            .id(chartType == .rom ? "romChart" : "painChart")
             // Subtitle
             if vm.chartData.isEmpty {
-                Text(chartType == .rom ? Strings.History.chartRomNoRecord : Strings.History.chartPainNoRecord)
-                    .font(.displayFootnoteRegular)
-                    .frame(
-                        maxWidth: .infinity,
-                        alignment: .leading
-                    )
+                Text(
+                    chartType == .rom
+                        ? Strings.History.chartRomNoRecord
+                        : Strings.History.chartPainNoRecord
+                )
+                .font(.displayFootnoteRegular)
+                .frame(
+                    maxWidth: .infinity,
+                    alignment: .leading
+                )
             } else {
                 Text(chartType == .rom ? vm.romSubtitle : vm.painSubtitle)
                     .font(.displayFootnoteRegular)
             }
         }
         .opacity(
-            (chartType == .rom ? vm.selectedROMIndex : vm.selectedPainIndex) != nil ? 0 : 1
+            (chartType == .rom ? vm.selectedROMIndex : vm.selectedPainIndex)
+                != nil ? 0 : 1
         )
         .animation(
             .easeInOut(duration: 0.1),
-            value: (chartType == .rom ? vm.selectedROMIndex : vm.selectedPainIndex)
+            value: (chartType == .rom
+                ? vm.selectedROMIndex : vm.selectedPainIndex)
         )
     }
-    
+
     // MARK: - Chart Views
     private var romChart: some View {
-        let week = ["일", "월", "화", "수", "목", "금", "토"]
         let data = vm.chartData
         let selectedIndex = vm.selectedROMIndex
-        
-        return Chart {
 
-            ForEach(data, id: \.record.id) { item in
-                BarMark(
-                    x: .value("index", item.index),
-                    yStart: .value("angle", item.record.extensionAngle ?? 0),
-                    yEnd: .value("angle", item.record.flexionAngle ?? 0),
-                    width: .fixed(12)
-                )
-                .foregroundStyle(
-                    Color("Blue500")
-                )
-                .cornerRadius(4)
+        let weekData = vm.getCurrentWeekData()  // 빈 데이터 가공
+
+        return Chart {
+            ForEach(0..<vm.week.count, id: \.self) { weekdayIndex in
+                let dayData = weekData[weekdayIndex]
+
+                if let record = dayData.record {
+                    BarMark(
+                        x: .value("weekday", weekdayIndex),
+                        yStart: .value("angle", record.extensionAngle ?? 0),
+                        yEnd: .value("angle", record.flexionAngle ?? 0),
+                        width: .fixed(12)
+                    )
+                    .foregroundStyle(
+                        Color("Blue500")
+                    )
+                    .cornerRadius(4)
+                } else {
+                    // 데이터가 없는 날 (빈 바)
+                    BarMark(
+                        x: .value("weekday", weekdayIndex),
+                        yStart: .value("angle", 0),
+                        yEnd: .value("angle", 0.5),
+                        width: .fixed(12)
+                    )
+                    .foregroundStyle(Color("Gray200").opacity(0.3))
+                    .cornerRadius(4)
+                }
             }
+            
 
             if let selectedIndex = selectedIndex,
-                selectedIndex >= 0 && selectedIndex < data.count
+               selectedIndex >= 0 && selectedIndex < vm.week.count
             {
-                RuleMark(x: .value("Selected", selectedIndex))
-                    .foregroundStyle(Color("Gray300"))
-                    .zIndex(-1)
-                    .annotation(
-                        position: .top,
-                        spacing: 8,
-                        overflowResolution: .init(
-                            x: .fit(to: .chart),
-                            y: .disabled
-                        )
-                    ) {
-                        romAnnotation
-                    }
+                let adjustedIndex = nearestAvailableIndex(from: selectedIndex, in: weekData)
+                if let adjustedIndex = adjustedIndex {
+                    RuleMark(x: .value("Selected", adjustedIndex))
+                        .foregroundStyle(Color("Gray300"))
+                        .zIndex(-1)
+                        .annotation(
+                            position: .top,
+                            spacing: 8,
+                            overflowResolution: .init(
+                                x: .fit(to: .chart),
+                                y: .disabled
+                            )
+                        ) {
+                            romAnnotation(at: adjustedIndex)
+                        }
+                }
             }
         }
         .chartXAxis {
-            AxisMarks(position: .bottom, values: vm.chartIndicesAsDouble) {
-                value in
-                if let doubleValue = value.as(Double.self) {
-                    let index = Int(round(doubleValue))
-                    // 정확한 인덱스 값인지 확인 (0.01 이내 오차 허용)
-                    if abs(doubleValue - Double(index)) < 0.01,
-                        index >= 0 && index < vm.recentRecords.count
-                    {
-                        let record = vm.recentRecords[index]
-                        let dateStr = vm.formatShortDate(record.measuredDate)
-                        AxisValueLabel {
-                            Text(dateStr)
-                                .offset(x: -17)
-                        }
-                    } else {
-                        AxisGridLine()
+            AxisMarks(values: .stride(by: 1)) { value in
+                if let index = value.as(Int.self),
+                    index >= 0 && index < 7
+                {
+                    AxisValueLabel {
+                        Text(vm.week[index])
+                            .font(.caption)
+                            .foregroundColor(.gray)
                     }
                 }
             }
@@ -174,18 +194,19 @@ struct History: View {
             }
         }
         .chartYScale(domain: 0...max(150, vm.romMaxValue))
-//        .chartXScale(domain: domain)
         .chartXSelection(value: $vm.selectedROMIndex)  //롱프레스 감지
         .frame(height: 361)
         .padding(.top, 20)
     }
 
     @ViewBuilder
-    private var romAnnotation: some View {
-        if let selectedIndex = vm.selectedROMIndex,
-            selectedIndex >= 0 && selectedIndex < vm.recentRecords.count
+    private func romAnnotation(at explicitIndex: Int? = nil) -> some View {
+        if let selectedIndex = explicitIndex ?? vm.selectedROMIndex,
+            selectedIndex >= 0 && selectedIndex < vm.week.count
         {
-            let selectedRecord = vm.recentRecords[selectedIndex]
+            let weekData = vm.getCurrentWeekData()
+
+            let selectedRecord = weekData[selectedIndex]
             VStack(alignment: .center, spacing: 4) {
                 Text(Strings.History.cardRomTitle)
                     .font(.displayCaption1Semibold)
@@ -193,16 +214,20 @@ struct History: View {
                     .frame(maxWidth: .infinity, alignment: .topLeading)
 
                 Text(
-                    "\(Int(selectedRecord.extensionAngle ?? 0))°~\(Int(selectedRecord.flexionAngle ?? 0))°"
+                    "\(Int(selectedRecord.record?.extensionAngle ?? 0))°~\(Int(selectedRecord.record?.flexionAngle ?? 0))°"
                 )
                 .font(.displayTitle2Semibold)
                 .foregroundStyle(Color("Gray900"))
                 .frame(maxWidth: .infinity, alignment: .topLeading)
 
-                Text(vm.formatDate(selectedRecord.measuredDate))
-                    .font(.displayCaption1Semibold)
-                    .foregroundStyle(Color("Gray700"))
-                    .frame(maxWidth: .infinity, alignment: .topLeading)
+                Text(
+                    selectedRecord.record?.measuredDate != nil
+                        ? vm.formatDate(selectedRecord.record!.measuredDate)
+                        : "-"
+                )
+                .font(.displayCaption1Semibold)
+                .foregroundStyle(Color("Gray700"))
+                .frame(maxWidth: .infinity, alignment: .topLeading)
             }
             .padding(.horizontal, 8)
             .padding(.vertical, 4)
@@ -214,7 +239,6 @@ struct History: View {
 
     private var painChart: some View {
         let data = vm.chartData
-//        let domain = vm.xAxisDomain
         let selectedIndex = vm.selectedPainIndex
 
         return Chart {
@@ -274,7 +298,7 @@ struct History: View {
             }
         }
         .chartYScale(domain: 0...10)
-//        .chartXScale(domain: domain)
+        //        .chartXScale(domain: domain)
         .chartXSelection(value: $vm.selectedPainIndex)
         .frame(height: 250)
         .padding(.top, 20)
@@ -428,6 +452,23 @@ struct History: View {
         guard let level = level else { return "-" }
         return "\(level)"
     }
+    
+    // 가장 가까운 기록이 있는 인덱스를 찾는 헬퍼
+    private func nearestAvailableIndex(from index: Int, in weekData: [HistoryViewModel.WeekDayData]) -> Int? {
+        guard index >= 0 && index < weekData.count else { return nil }
+        if weekData[index].record != nil { return index }
+        var offset = 1
+        while index - offset >= 0 || index + offset < weekData.count {
+            if index - offset >= 0, weekData[index - offset].record != nil {
+                return index - offset
+            }
+            if index + offset < weekData.count, weekData[index + offset].record != nil {
+                return index + offset
+            }
+            offset += 1
+        }
+        return nil
+    }
 }
 
 // MARK: - Previews
@@ -481,3 +522,4 @@ struct HistoryPreviewWrapper: View {
 //#Preview("Extended Records (11+)") {
 //    HistoryPreviewWrapper(scenario: .extendedRecords)
 //}
+

--- a/gacha/gacha/Views/DashBoard/HistoryView.swift
+++ b/gacha/gacha/Views/DashBoard/HistoryView.swift
@@ -70,16 +70,16 @@ struct History: View {
     // MARK: - Chart Text
     private func ChartText(chartType: ChartType) -> some View {
         return VStack(alignment: .leading, spacing: 16) {
-            VStack(alignment: .leading, spacing: 4) {
-                // Title
-                Text(
-                    chartType == .rom
-                        ? Strings.History.chartRomTitle
-                        : Strings.History.chartPainTitle
-                )
-                .font(.displaySublineBold)
-                .foregroundColor(.blue700)
-                .id(chartType == .rom ? "romChart" : "painChart")
+            // Title
+            Text(
+                chartType == .rom
+                    ? Strings.History.chartRomTitle
+                    : Strings.History.chartPainTitle
+            )
+            .font(.displaySublineBold)
+            .foregroundColor(.blue700)
+            .id(chartType == .rom ? "romChart" : "painChart")
+            VStack(alignment: .leading, spacing: 8) {
                 // Subtitle
                 if vm.chartData.isEmpty {
                     Text(
@@ -96,21 +96,26 @@ struct History: View {
                     Text(chartType == .rom ? vm.romSubtitle : vm.painSubtitle)
                         .font(.displayFootnoteRegular)
                 }
+
+                // Buttons & Date
+                if !vm.chartData.isEmpty {
+                    if chartType == .rom {
+                        romChartButton
+                    } else {
+                        painChartButton
+                    }
+                }
             }
-            // Buttons & Date
-            if !vm.chartData.isEmpty {
-                if chartType == .rom { romChartButton } else { painChartButton }
-            }
+            .opacity(
+                (chartType == .rom ? vm.selectedROMIndex : vm.selectedPainIndex)
+                    != nil ? 0 : 1
+            )
+            .animation(
+                .easeInOut(duration: 0.1),
+                value: (chartType == .rom
+                    ? vm.selectedROMIndex : vm.selectedPainIndex)
+            )
         }
-        .opacity(
-            (chartType == .rom ? vm.selectedROMIndex : vm.selectedPainIndex)
-                != nil ? 0 : 1
-        )
-        .animation(
-            .easeInOut(duration: 0.1),
-            value: (chartType == .rom
-                ? vm.selectedROMIndex : vm.selectedPainIndex)
-        )
     }
 
     // MARK: - romChartButton
@@ -501,7 +506,7 @@ struct History: View {
                                 y: .disabled
                             )
                         ) {
-                            romAnnotation(at: adjustedIndex)
+                            painAnnotation(at: adjustedIndex)
                         }
                 }
             }
@@ -532,26 +537,30 @@ struct History: View {
     }
 
     @ViewBuilder
-    private var painAnnotation: some View {
-        if let selectedIndex = vm.selectedPainIndex,
-            selectedIndex >= 0 && selectedIndex < vm.recentRecords.count
+    private func painAnnotation(at explicitIndex: Int? = nil) -> some View {
+        if let selectedIndex = explicitIndex ?? vm.selectedROMIndex,
+            selectedIndex >= 0 && selectedIndex < vm.week.count
         {
-            let selectedRecord = vm.recentRecords[selectedIndex]
+            let weekData = vm.getCurrentWeekData(type: .pain)
+            let selectedRecord = weekData[selectedIndex].record
             VStack(alignment: .leading, spacing: 4) {
                 Text(Strings.History.cardPainTitle)
                     .font(.displayCaption1Semibold)
                     .foregroundStyle(Color("Gray700"))
                     .frame(maxWidth: .infinity, alignment: .topLeading)
 
-                Text(formatPainLevel(selectedRecord.painLevel))
+                Text(formatPainLevel(selectedRecord?.painLevel))
                     .font(.displayTitle2Semibold)
                     .foregroundStyle(Color("Gray900"))
                     .frame(maxWidth: .infinity, alignment: .topLeading)
 
-                Text(vm.formatDate(selectedRecord.measuredDate))
-                    .font(.displayCaption1Semibold)
-                    .foregroundStyle(Color("Gray700"))
-                    .frame(maxWidth: .infinity, alignment: .topLeading)
+                Text(
+                    selectedRecord?.measuredDate != nil
+                        ? vm.formatDate(selectedRecord!.measuredDate) : "-"
+                )
+                .font(.displayCaption1Semibold)
+                .foregroundStyle(Color("Gray700"))
+                .frame(maxWidth: .infinity, alignment: .topLeading)
 
             }
             .padding(.horizontal, 8)

--- a/gacha/gacha/Views/DashBoard/HistoryView.swift
+++ b/gacha/gacha/Views/DashBoard/HistoryView.swift
@@ -147,12 +147,14 @@ struct History: View {
                     .cornerRadius(4)
                 }
             }
-            
 
             if let selectedIndex = selectedIndex,
-               selectedIndex >= 0 && selectedIndex < vm.week.count
+                selectedIndex >= 0 && selectedIndex < vm.week.count
             {
-                let adjustedIndex = nearestAvailableIndex(from: selectedIndex, in: weekData)
+                let adjustedIndex = nearestAvailableIndex(
+                    from: selectedIndex,
+                    in: weekData
+                )
                 if let adjustedIndex = adjustedIndex {
                     RuleMark(x: .value("Selected", adjustedIndex))
                         .foregroundStyle(Color("Gray300"))
@@ -171,13 +173,11 @@ struct History: View {
             }
         }
         .chartXAxis {
-            AxisMarks(position: .bottom, values: vm.chartIndicesAsDouble) {
+            AxisMarks(values: .stride(by: 1)) {
                 value in
-                if let doubleValue = value.as(Double.self) {
-                    let index = Int(round(doubleValue))
-                    // 정확한 인덱스 값인지 확인 (0.01 이내 오차 허용)
+                if let index = value.as(Double.self) {
                     if let index = value.as(Int.self),
-                        index >= 0 && index < 7
+                        index >= 0 && index < vm.week.count
                     {
                         AxisValueLabel {
                             Text(vm.week[index])
@@ -472,9 +472,12 @@ struct History: View {
         guard let level = level else { return "-" }
         return "\(level)"
     }
-    
+
     // 가장 가까운 기록이 있는 인덱스를 찾는 헬퍼
-    private func nearestAvailableIndex(from index: Int, in weekData: [HistoryViewModel.WeekDayData]) -> Int? {
+    private func nearestAvailableIndex(
+        from index: Int,
+        in weekData: [HistoryViewModel.WeekDayData]
+    ) -> Int? {
         guard index >= 0 && index < weekData.count else { return nil }
         if weekData[index].record != nil { return index }
         var offset = 1
@@ -482,7 +485,9 @@ struct History: View {
             if index - offset >= 0, weekData[index - offset].record != nil {
                 return index - offset
             }
-            if index + offset < weekData.count, weekData[index + offset].record != nil {
+            if index + offset < weekData.count,
+                weekData[index + offset].record != nil
+            {
                 return index + offset
             }
             offset += 1
@@ -542,4 +547,3 @@ struct HistoryPreviewWrapper: View {
 //#Preview("Extended Records (11+)") {
 //    HistoryPreviewWrapper(scenario: .extendedRecords)
 //}
-

--- a/gacha/gacha/Views/DashBoard/HistoryView.swift
+++ b/gacha/gacha/Views/DashBoard/HistoryView.swift
@@ -9,11 +9,6 @@ import Charts
 import SwiftData
 import SwiftUI
 
-enum ChartType: Hashable {
-    case rom
-    case pain
-}
-
 struct History: View {
     @EnvironmentObject var vm: HistoryViewModel
 
@@ -64,7 +59,6 @@ struct History: View {
                         .padding(.bottom, 20)
                     }
                 }
-
             }
         }
         .background(Color("BackgoundSecondary"))
@@ -75,9 +69,6 @@ struct History: View {
 
     // MARK: - Chart Text
     private func ChartText(chartType: ChartType) -> some View {
-        let weekData = vm.getCurrentWeekData()
-        let calendar = Calendar.current
-
         return VStack(alignment: .leading, spacing: 16) {
             VStack(alignment: .leading, spacing: 4) {
                 // Title
@@ -108,20 +99,7 @@ struct History: View {
             }
             // Buttons & Date
             if !vm.chartData.isEmpty {
-                HStack {
-                    romChartButtonLeft
-
-                    Spacer()
-
-                    Text(
-                        "\(vm.formatDate(weekData.first?.date ?? Date())) - \(vm.formatDate(weekData.last?.date ?? Date()))"
-                    )
-                    .font(.displayFootnoteRegular)
-
-                    Spacer()
-
-                    romChartButtonRight
-                }
+                if chartType == .rom { romChartButton } else { painChartButton }
             }
         }
         .opacity(
@@ -135,9 +113,30 @@ struct History: View {
         )
     }
 
+    // MARK: - romChartButton
+    private var romChartButton: some View {
+        let weekData = vm.getCurrentWeekData(type: .rom)
+
+        return HStack {
+
+            romChartButtonLeft
+
+            Spacer()
+
+            Text(
+                "\(vm.formatDate(weekData.first?.date ?? Date())) - \(vm.formatDate(weekData.last?.date ?? Date()))"
+            )
+            .font(.displayFootnoteRegular)
+
+            Spacer()
+
+            romChartButtonRight
+        }
+    }
+
     private var romChartButtonLeft: some View {
         // 현재 주(오프셋 적용)의 주간 범위 계산
-        let weekData = vm.getCurrentWeekData()
+        let weekData = vm.getCurrentWeekData(type: .rom)
         let calendar = Calendar.current
         let currentWeekDates = weekData.compactMap { $0.date }
         let currentWeekStart = currentWeekDates.min()
@@ -165,7 +164,7 @@ struct History: View {
         return
             Button {
                 if !disableLeft {
-                    vm.currentWeekOffset += 1
+                    vm.currentROMWeekOffset += 1
                     vm.selectedROMIndex = nil
                 }
             } label: {
@@ -176,7 +175,7 @@ struct History: View {
 
     private var romChartButtonRight: some View {
         // 현재 주(오프셋 적용)의 주간 범위 계산
-        let weekData = vm.getCurrentWeekData()
+        let weekData = vm.getCurrentWeekData(type: .rom)
         let calendar = Calendar.current
         let currentWeekDates = weekData.compactMap { $0.date }
         let currentWeekStart = currentWeekDates.min()
@@ -205,7 +204,7 @@ struct History: View {
         return
             Button {
                 if !disableRight {
-                    vm.currentWeekOffset -= 1
+                    vm.currentROMWeekOffset -= 1
                     vm.selectedROMIndex = nil
                 }
             } label: {
@@ -220,7 +219,7 @@ struct History: View {
         let data = vm.chartData
         let selectedIndex = vm.selectedROMIndex
 
-        let weekData = vm.getCurrentWeekData()  // 빈 데이터 가공
+        let weekData = vm.getCurrentWeekData(type: .rom)  // 빈 데이터 가공
 
         return Chart {
             ForEach(0..<vm.week.count, id: \.self) { weekdayIndex in
@@ -291,19 +290,6 @@ struct History: View {
                 }
             }
         }
-        .chartXAxis {
-            AxisMarks(values: .stride(by: 1)) { value in
-                if let index = value.as(Int.self),
-                    index >= 0 && index < 7
-                {
-                    AxisValueLabel {
-                        Text(vm.week[index])
-                            .font(.caption)
-                            .foregroundColor(.gray)
-                    }
-                }
-            }
-        }
         .chartYAxis {
             AxisMarks { value in
                 AxisValueLabel {
@@ -326,7 +312,7 @@ struct History: View {
         if let selectedIndex = explicitIndex ?? vm.selectedROMIndex,
             selectedIndex >= 0 && selectedIndex < vm.week.count
         {
-            let weekData = vm.getCurrentWeekData()
+            let weekData = vm.getCurrentWeekData(type: .rom)
 
             let selectedRecord = weekData[selectedIndex]
             VStack(alignment: .center, spacing: 4) {
@@ -359,68 +345,187 @@ struct History: View {
         }
     }
 
+    // MARK: - painChartButton
+    private var painChartButton: some View {
+        let weekData = vm.getCurrentWeekData(type: .pain)
+
+        return HStack {
+
+            painChartButtonLeft
+
+            Spacer()
+
+            Text(
+                "\(vm.formatDate(weekData.first?.date ?? Date())) - \(vm.formatDate(weekData.last?.date ?? Date()))"
+            )
+            .font(.displayFootnoteRegular)
+
+            Spacer()
+
+            painChartButtonRight
+        }
+    }
+
+    private var painChartButtonLeft: some View {
+        // 현재 주(오프셋 적용)의 주간 범위 계산
+        let weekData = vm.getCurrentWeekData(type: .pain)
+        let calendar = Calendar.current
+        let currentWeekDates = weekData.compactMap { $0.date }
+        let currentWeekStart = currentWeekDates.min()
+        let currentWeekEnd = currentWeekDates.max()
+
+        // 전체 데이터의 첫/마지막 날짜
+        let dataStart = vm.recentRecords.first?.measuredDate
+        let dataEnd = vm.recentRecords.last?.measuredDate
+
+        // 왼쪽(과거로 이동): 이동 후 주의 끝이 데이터 시작일보다 앞서면 비활성화
+        let disableLeft: Bool = {
+            guard let currentWeekStart, let currentWeekEnd, let dataStart else {
+                return true
+            }
+            guard
+                let previousWeekEnd = calendar.date(
+                    byAdding: .day,
+                    value: -1,
+                    to: currentWeekStart
+                )
+            else { return true }
+            return previousWeekEnd < calendar.startOfDay(for: dataStart)
+        }()
+
+        return
+            Button {
+                if !disableLeft {
+                    vm.currentPainWeekOffset += 1
+                    vm.selectedPainIndex = nil
+                }
+            } label: {
+                Image(systemName: "chevron.left")
+            }
+            .disabled(disableLeft)
+    }
+
+    private var painChartButtonRight: some View {
+        // 현재 주(오프셋 적용)의 주간 범위 계산
+        let weekData = vm.getCurrentWeekData(type: .pain)
+        let calendar = Calendar.current
+        let currentWeekDates = weekData.compactMap { $0.date }
+        let currentWeekStart = currentWeekDates.min()
+        let currentWeekEnd = currentWeekDates.max()
+
+        // 전체 데이터의 첫/마지막 날짜
+        let dataStart = vm.recentRecords.first?.measuredDate
+        let dataEnd = vm.recentRecords.last?.measuredDate
+
+        // 오른쪽(미래로 이동): 이동 후 주의 시작이 데이터 마지막보다 뒤면 비활성화
+        let disableRight: Bool = {
+            guard let currentWeekStart, let currentWeekEnd, let dataEnd else {
+                return true
+            }
+            guard
+                let nextWeekStart = calendar.date(
+                    byAdding: .day,
+                    value: 1,
+                    to: currentWeekEnd
+                )
+            else { return true }
+            return calendar.startOfDay(for: nextWeekStart)
+                > calendar.startOfDay(for: dataEnd)
+        }()
+
+        return
+            Button {
+                if !disableRight {
+                    vm.currentPainWeekOffset -= 1
+                    vm.selectedPainIndex = nil
+                }
+            } label: {
+                Image(systemName: "chevron.right")
+            }
+            .disabled(disableRight)
+
+    }
+
     private var painChart: some View {
         let data = vm.chartData
         let selectedIndex = vm.selectedPainIndex
 
+        let weekData = vm.getCurrentWeekData(type: .pain)  // 빈 데이터 가공
+
         return Chart {
-            ForEach(data, id: \.record.id) { item in
-                LineMark(
-                    x: .value("index", item.index),
-                    y: .value("pain", item.record.painLevel ?? 0)
-                )
-                .foregroundStyle(Color(.blue500))
-                .interpolationMethod(.catmullRom)
+            ForEach(0..<vm.week.count, id: \.self) { weekdayIndex in
+                let dayData = weekData[weekdayIndex]
 
-                PointMark(
-                    x: .value("index", item.index),
-                    y: .value("pain", item.record.painLevel ?? 0)
-                )
-                .foregroundStyle(Color("Blue500"))
-                .symbolSize(80)
+                if let record = dayData.record {
+                    LineMark(
+                        x: .value("weekday", weekdayIndex),
+                        y: .value("pain", record.painLevel ?? 0)
+                    )
+                    .foregroundStyle(Color(.blue500))
+                    .interpolationMethod(.catmullRom)
+                    PointMark(
+                        x: .value("weekday", weekdayIndex),
+                        y: .value("pain", record.painLevel ?? 0),
+                    )
+                    .foregroundStyle(Color("Blue500"))
+                    .symbolSize(80)
+
+                } else {
+                    // 데이터가 없는 날 (빈 바)
+                    BarMark(
+                        x: .value("weekday", weekdayIndex),
+                        yStart: .value("angle", 0),
+                        yEnd: .value("angle", 0.5),
+                        width: .fixed(12)
+                    )
+                    .foregroundStyle(Color("Gray200").opacity(0.3))
+                    .cornerRadius(4)
+                }
             }
-
             if let selectedIndex = selectedIndex,
-                selectedIndex >= 0 && selectedIndex < data.count
+                selectedIndex >= 0 && selectedIndex < vm.week.count
             {
-                RuleMark(x: .value("Selected", selectedIndex))
-                    .foregroundStyle(Color("Gray300"))
-                    .zIndex(-1)
-                    .annotation(
-                        position: .top,
-                        spacing: 0,
-                        overflowResolution: .init(
-                            x: .fit(to: .chart),
-                            y: .disabled
-                        )
-                    ) {
-                        painAnnotation
-                    }
+                let adjustedIndex = nearestAvailableIndex(
+                    from: selectedIndex,
+                    in: weekData
+                )
+                if let adjustedIndex = adjustedIndex {
+                    RuleMark(x: .value("Selected", adjustedIndex))
+                        .foregroundStyle(Color("Gray300"))
+                        .zIndex(-1)
+                        .annotation(
+                            position: .top,
+                            spacing: 8,
+                            overflowResolution: .init(
+                                x: .fit(to: .chart),
+                                y: .disabled
+                            )
+                        ) {
+                            romAnnotation(at: adjustedIndex)
+                        }
+                }
             }
         }
         .chartXAxis {
-            AxisMarks(position: .bottom, values: vm.chartIndicesAsDouble) {
+            AxisMarks(values: .stride(by: 1)) {
                 value in
-                if let doubleValue = value.as(Double.self) {
-                    let index = Int(round(doubleValue))
-                    // 정확한 인덱스 값인지 확인 (0.01 이내 오차 허용)
-                    if abs(doubleValue - Double(index)) < 0.01,
-                        index >= 0 && index < vm.recentRecords.count
+                if let index = value.as(Double.self) {
+                    if let index = value.as(Int.self),
+                        index >= 0 && index < vm.week.count
                     {
-                        let record = vm.recentRecords[index]
-                        let dateStr = vm.formatShortDate(record.measuredDate)
+                        AxisGridLine(centered: true)
                         AxisValueLabel {
-                            Text(dateStr)
-                                .offset(x: -17)
+                            Text(vm.week[index])
+                                .font(.caption)
+                                .foregroundColor(.gray)
+                                .offset(x: -10)
                         }
-                    } else {
-                        AxisGridLine()
                     }
                 }
             }
         }
+        .chartXScale(domain: -0.5...6.5)
         .chartYScale(domain: 0...10)
-        //        .chartXScale(domain: domain)
         .chartXSelection(value: $vm.selectedPainIndex)
         .frame(height: 250)
         .padding(.top, 20)

--- a/gacha/gacha/Views/DashBoard/HistoryView.swift
+++ b/gacha/gacha/Views/DashBoard/HistoryView.swift
@@ -9,6 +9,11 @@ import Charts
 import SwiftData
 import SwiftUI
 
+enum ChartType: Hashable {
+    case rom
+    case pain
+}
+
 struct History: View {
     @EnvironmentObject var vm: HistoryViewModel
 
@@ -32,35 +37,7 @@ struct History: View {
 
                             // MARK: - ROM Chart
                             VStack(alignment: .leading, spacing: 16) {
-                                // Text
-                                VStack(alignment: .leading, spacing: 4) {
-                                    // Title
-                                    Text(Strings.History.chartRomTitle)
-                                        .font(.displaySublineBold)
-                                        .foregroundColor(.blue700)
-                                        .id("romChart")
-                                    // Subtitle
-                                    if vm.chartData.isEmpty {
-                                        Text(Strings.History.chartRomNoRecord)
-                                            .font(.displayFootnoteRegular)
-                                            .frame(
-                                                maxWidth: .infinity,
-                                                alignment: .leading
-                                            )
-                                    } else {
-                                        Text(vm.romSubtitle)
-                                            .font(.displayFootnoteRegular)
-                                    }
-                                }
-                                .opacity(
-                                    vm.selectedROMIndex != nil ? 0 : 1
-                                )
-                                .animation(
-                                    .easeInOut(duration: 0.1),
-                                    value: vm.selectedROMIndex
-                                )
-                                
-                                // Chart
+                                ChartText(chartType: .rom)
                                 if !vm.chartData.isEmpty {
                                     romChart
                                 }
@@ -72,36 +49,7 @@ struct History: View {
 
                             // MARK: - Pain Chart
                             VStack(alignment: .leading, spacing: 16) {
-                                // Text
-                                VStack(alignment: .leading, spacing: 4) {
-                                    // Title
-                                    Text(Strings.History.chartPainTitle)
-                                        .font(.displaySublineBold)
-                                        .foregroundColor(.blue700)
-                                        .id("painChart")
-
-                                    // Subtitle
-                                    if vm.chartData.isEmpty {
-                                        // No Data
-                                        Text(Strings.History.chartPainNoRecord)
-                                            .font(.displayFootnoteRegular)
-                                            .frame(
-                                                maxWidth: .infinity,
-                                                alignment: .leading
-                                            )
-                                    } else {
-                                        Text(vm.painSubtitle)
-                                            .font(.displayFootnoteRegular)
-                                    }
-                                }.opacity(
-                                    vm.selectedPainIndex != nil ? 0 : 1
-                                )
-                                .animation(
-                                    .easeInOut(duration: 0.1),
-                                    value: vm.selectedPainIndex
-                                )
-                                
-                                // Chart
+                                ChartText(chartType: .pain)
                                 if !vm.chartData.isEmpty {
                                     painChart
                                 }
@@ -125,13 +73,42 @@ struct History: View {
         }
     }
 
+    // MARK: - Chart Text
+    private func ChartText(chartType: ChartType) -> some View {
+        return VStack(alignment: .leading, spacing: 4) {
+            // Title
+            Text(chartType == .rom ? Strings.History.chartRomTitle : Strings.History.chartPainTitle)
+                .font(.displaySublineBold)
+                .foregroundColor(.blue700)
+                .id(chartType == .rom ? "romChart" : "painChart")
+            // Subtitle
+            if vm.chartData.isEmpty {
+                Text(chartType == .rom ? Strings.History.chartRomNoRecord : Strings.History.chartPainNoRecord)
+                    .font(.displayFootnoteRegular)
+                    .frame(
+                        maxWidth: .infinity,
+                        alignment: .leading
+                    )
+            } else {
+                Text(chartType == .rom ? vm.romSubtitle : vm.painSubtitle)
+                    .font(.displayFootnoteRegular)
+            }
+        }
+        .opacity(
+            (chartType == .rom ? vm.selectedROMIndex : vm.selectedPainIndex) != nil ? 0 : 1
+        )
+        .animation(
+            .easeInOut(duration: 0.1),
+            value: (chartType == .rom ? vm.selectedROMIndex : vm.selectedPainIndex)
+        )
+    }
+    
     // MARK: - Chart Views
-
     private var romChart: some View {
+        let week = ["일", "월", "화", "수", "목", "금", "토"]
         let data = vm.chartData
-        let domain = vm.xAxisDomain
         let selectedIndex = vm.selectedROMIndex
-
+        
         return Chart {
 
             ForEach(data, id: \.record.id) { item in
@@ -146,17 +123,6 @@ struct History: View {
                 )
                 .cornerRadius(4)
             }
-
-            // 도딘의 유산
-            // 130도 기준선
-            //            RuleMark(y: .value("Target", 130))
-            //                .foregroundStyle(Color("Blue700"))
-            //                .lineStyle(StrokeStyle(lineWidth: 1, dash: [5, 5]))
-            //                .annotation(position: .trailing, alignment: .center) {
-            //                    Text("130°")
-            //                        .font(.displayCaption1Regular)
-            //                        .foregroundStyle(Color("Blue700"))
-            //                }
 
             if let selectedIndex = selectedIndex,
                 selectedIndex >= 0 && selectedIndex < data.count
@@ -208,7 +174,7 @@ struct History: View {
             }
         }
         .chartYScale(domain: 0...max(150, vm.romMaxValue))
-        .chartXScale(domain: domain)
+//        .chartXScale(domain: domain)
         .chartXSelection(value: $vm.selectedROMIndex)  //롱프레스 감지
         .frame(height: 361)
         .padding(.top, 20)
@@ -248,7 +214,7 @@ struct History: View {
 
     private var painChart: some View {
         let data = vm.chartData
-        let domain = vm.xAxisDomain
+//        let domain = vm.xAxisDomain
         let selectedIndex = vm.selectedPainIndex
 
         return Chart {
@@ -308,7 +274,7 @@ struct History: View {
             }
         }
         .chartYScale(domain: 0...10)
-        .chartXScale(domain: domain)
+//        .chartXScale(domain: domain)
         .chartXSelection(value: $vm.selectedPainIndex)
         .frame(height: 250)
         .padding(.top, 20)

--- a/gacha/gacha/Views/DashBoard/HistoryView.swift
+++ b/gacha/gacha/Views/DashBoard/HistoryView.swift
@@ -171,6 +171,25 @@ struct History: View {
             }
         }
         .chartXAxis {
+            AxisMarks(position: .bottom, values: vm.chartIndicesAsDouble) {
+                value in
+                if let doubleValue = value.as(Double.self) {
+                    let index = Int(round(doubleValue))
+                    // 정확한 인덱스 값인지 확인 (0.01 이내 오차 허용)
+                    if let index = value.as(Int.self),
+                        index >= 0 && index < 7
+                    {
+                        AxisValueLabel {
+                            Text(vm.week[index])
+                                .font(.caption)
+                                .foregroundColor(.gray)
+                                .offset(x: -10)
+                        }
+                    }
+                }
+            }
+        }
+        .chartXAxis {
             AxisMarks(values: .stride(by: 1)) { value in
                 if let index = value.as(Int.self),
                     index >= 0 && index < 7
@@ -193,6 +212,7 @@ struct History: View {
                 AxisGridLine()
             }
         }
+        .chartXScale(domain: -0.5...6.5)
         .chartYScale(domain: 0...max(150, vm.romMaxValue))
         .chartXSelection(value: $vm.selectedROMIndex)  //롱프레스 감지
         .frame(height: 361)

--- a/gacha/gacha/Views/DashBoard/HistoryView.swift
+++ b/gacha/gacha/Views/DashBoard/HistoryView.swift
@@ -39,6 +39,7 @@ struct History: View {
                             VStack(alignment: .leading, spacing: 16) {
                                 ChartText(chartType: .rom)
                                 if !vm.chartData.isEmpty {
+                                    romChartButton
                                     romChart
                                 }
                             }
@@ -111,6 +112,31 @@ struct History: View {
             value: (chartType == .rom
                 ? vm.selectedROMIndex : vm.selectedPainIndex)
         )
+    }
+
+    private var romChartButton: some View {
+        return HStack {
+            Button {
+                vm.currentWeekOffset += 1
+                vm.selectedROMIndex = nil
+
+            } label: {
+                Image(systemName: "chevron.left")
+            }
+            //            .disabled()
+
+            Spacer()
+
+            Button {
+                vm.currentWeekOffset -= 1
+                vm.selectedROMIndex = nil
+
+            } label: {
+                Image(systemName: "chevron.right")
+            }
+            //            .disabled()
+        }
+        .padding(.horizontal)
     }
 
     // MARK: - Chart Views

--- a/gacha/gacha/Views/DashBoard/HistoryView.swift
+++ b/gacha/gacha/Views/DashBoard/HistoryView.swift
@@ -143,8 +143,8 @@ struct History: View {
         let currentWeekEnd = currentWeekDates.max()
 
         // 전체 데이터의 첫/마지막 날짜
-        let dataStart = vm.recentRecords.first?.measuredDate
-        let dataEnd = vm.recentRecords.last?.measuredDate
+        let dataStart = vm.allRecords.first?.measuredDate
+        let dataEnd = vm.allRecords.last?.measuredDate
 
         // 왼쪽(과거로 이동): 이동 후 주의 끝이 데이터 시작일보다 앞서면 비활성화
         let disableLeft: Bool = {


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #이슈번호

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- chartText 컴포넌트화 : 차트의 상단의 타이틀과 서브타이틀을 .opacity 애니메이션 적용되는 텍스트 묶을 컴포넌트화
- 일주일 간격 데이터 생성 : currentROMWeekOffset, currentPainWeekOffset으로 현재 기준 몇주전인지 관리하고, week을 데이터로 등록해 getCurrentWeekData에서 해당하는 주차의 일~토의 모든 데이터를 생성하고 차트에 보여주도록 함
- Bar 위치 정렬 : chartXAxis으로 날짜(축)의 중앙에 바가 나타나도록 수정
- 일주일 넘김 버튼 : 주를 이동하는 버튼을 ROM과 Pain을 따로 생성해서 구현

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

<img width="234" height="461" alt="스크린샷 2026-01-24 오후 11 43 07" src="https://github.com/user-attachments/assets/6d286cc1-0d1a-42f9-a3a0-4533f6b689cf" /> <img width="232" height="461" alt="스크린샷 2026-01-24 오후 11 42 54" src="https://github.com/user-attachments/assets/467b900f-92b8-436a-8bcd-8914d00ad0a9" />

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [ ] 빌드 및 런타임 오류 없음
- [ ] 기기 테스트 완료
- [ ] PR 제목 컨벤션 지킴
- [ ] 불필요한 코드 제거
- [ ] 리뷰 준비 완료

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- 코드가 많이 지저분하고 사용되지 않는 함수도 많고, 하나로 합칠 수 있는 변수도 있는 것 같은데 시간관계상 일단 구현만 해둡니다
- 이후에 HistoryView와 HistoryViewModel 리팩토링으로 개선 필요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * ROM/통증 차트의 주(週) 단위 탐색 및 주별 데이터 조회 기능 추가
  * 차트별 좌/우 네비게이션 버튼으로 주간 이동 및 범위 외 이동 시 비활성화 처리
  * 차트 헤더/서브타이틀을 통합한 공통 렌더링 컴포넌트 도입

* **개선 사항**
  * 주 기반 렌더링으로 일별 플레이스홀더 표시 및 누락 데이터 안전 처리
  * 선택 항목에 가까운 유효 데이터로 주석·하이라이트 정렬 및 X축 요일 레이블 개선
  * 요약 카드 텍스트·레이아웃 정비로 가독성 향상

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->