### PR TITLE
✨ Feature: 측정뷰에서 프로그래스바가 0%~100%로 매끄럽게 채워지지 않는 문제 해결 

### DIFF
--- a/gacha/gacha/ViewModels/MeasureViewModel.swift
+++ b/gacha/gacha/ViewModels/MeasureViewModel.swift
@@ -63,12 +63,12 @@ final class MeasureViewModel: ObservableObject {
         case .idle:
             return 0.0
         case .started:
-            return 0.1  // 시작
+            return 0.0  // 시작
         case .moving:
             return 0.0  // 움직임 감지
         case .stabilizing:
-            // 0.3에서 1.0까지 (stabilizingProgress 기반)
-            return 0.2 + (stabilizingProgress * 0.7)
+            // 전체 과정 3초
+            return stabilizingProgress
         case .completed:
             return 1.0
         }

--- a/gacha/gacha/ViewModels/MeasureViewModel.swift
+++ b/gacha/gacha/ViewModels/MeasureViewModel.swift
@@ -65,7 +65,7 @@ final class MeasureViewModel: ObservableObject {
         case .started:
             return 0.1  // 시작
         case .moving:
-            return 0.2  // 움직임 감지
+            return 0.0  // 움직임 감지
         case .stabilizing:
             // 0.3에서 1.0까지 (stabilizingProgress 기반)
             return 0.2 + (stabilizingProgress * 0.7)


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #8 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- overallProgress에서 기본으로 주어지는 오프셋 수정
- 측정치에 급격한 변화가 있을 때 20%가 아니라 0%로 프로그레스 바가 내려가도록 설정
- 기존 90%에서 급격하게 빨라지던 프로그레스 바 변화를 모든 단계에서와 동일한 속도로 차오르게 설정
- 총 측정 시간이 3초가 되로록 설정

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->


https://github.com/user-attachments/assets/07f29865-1be8-4af0-b96d-ba6f26b1c298



---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] 빌드 및 런타임 오류 없음
- [x] 기기 테스트 완료
- [x] PR 제목 컨벤션 지킴
- [x] 불필요한 코드 제거
- [x] 리뷰 준비 완료

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- 폄, 굽힘 모두 잘 작동합니다!
- 다만 햅틱이 어떻게 짜여져 있는지 확인을 해보아야 알 수 있는 문제가 있는데, 이를테면 70%까지 측정을 한 이후 급격한 각도의 변화가 발생해서 0%까지 프로그레스 바가 내려온 다음 다시 측정을 진행하게 되면 70% 이상이 되는 지점에 도달하기 전까지는 이전처럼 햅틱이 발생하지 않습니다. 소소한 문제이지만 나중에 뜯어봐서 고치면 좋을 것 같기도?



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 안정화 상태에서 진행률 계산 로직을 개선하여 더 정확한 진행 상황을 표시하도록 수정했습니다.
  * 안정화 단계에서 UI 진행 피드백이 더욱 직관적으로 업데이트됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->